### PR TITLE
Lowered the amount of copy paste required in custom card json definition

### DIFF
--- a/CardDataWrapperBase.cs
+++ b/CardDataWrapperBase.cs
@@ -5,13 +5,6 @@
         // these must be fields and camel case is for consistency - blame JsonUtility
         public string imageFileName;
         public string itemId;
-        private string upgradesToC;
-
-        public string UpgradesToC
-        {
-            get => this.upgradesToC;
-            set => this.upgradesToC = value;
-        }
 
         /// <summary>
         /// Fires before MatchManager.CastCard gets called.

--- a/Patches/CustomDataLoader/CreateCardClonesPrefix.cs
+++ b/Patches/CustomDataLoader/CreateCardClonesPrefix.cs
@@ -156,13 +156,7 @@ public class CreateCardClonesPrefix
 
         // if its not the base card setup the id for it
         if (newCard.CardUpgraded != CardUpgraded.No)
-        {
-            if (string.IsNullOrWhiteSpace(newCard.BaseCard))
-            {
-                Plugin.Logger.LogError($"Custom card '{newCard.CardName}' is upgrade type '{newCard.CardUpgraded}', but is missing 'baseCard' field in json.");
-                return;
-            }
-            
+        {            
             newCard.Id = newCard.BaseCard.AppendNotNullOrWhiteSpace(cardUpgradeAppendString[newCard.CardUpgraded]);
             newCard.UpgradedFrom = newCard.BaseCard;
         }
@@ -245,7 +239,7 @@ public class CreateCardClonesPrefix
         {
             if (string.IsNullOrWhiteSpace(newCard.BaseCard))
             {
-                Plugin.Logger.LogError($"Upgraded Card: '{newCard.CardName}' '{newCard.CardUpgraded}' is missing the required json field 'baseCard'.");
+                Plugin.Logger.LogError($"Custom card '{newCard.CardName}' is upgrade type '{newCard.CardUpgraded}', but is missing 'baseCard' field in json.");
                 return null;
             }
         }

--- a/Patches/CustomDataLoader/CreateCardClonesPrefix.cs
+++ b/Patches/CustomDataLoader/CreateCardClonesPrefix.cs
@@ -221,6 +221,7 @@ public class CreateCardClonesPrefix
         JsonUtility.FromJsonOverwrite(json, newCard);
         newCard.LoadSprite(cardFileInfo);
 
+        // validate base cards
         if (newCard.CardUpgraded == CardUpgraded.No)
         {
             if (string.IsNullOrWhiteSpace(newCard.Id))
@@ -231,7 +232,7 @@ public class CreateCardClonesPrefix
             }
             else if (RegexUtils.HasInvalidIdRegex.IsMatch(newCard.Id))
             {
-                Plugin.Logger.LogError($"Card: '{newCard.CardName} has an invalid Id: {newCard.Id}, ids should only consist of letters and numbers.");
+                Plugin.Logger.LogError($"Card: '{newCard.CardName}' has an invalid Id: {newCard.Id}, ids should only consist of letters and numbers.");
                 return null;
             }
             else
@@ -239,7 +240,15 @@ public class CreateCardClonesPrefix
                 newCard.Id = newCard.Id.ToLower();
             }
         }
-
+        // validate upgraded cards
+        else 
+        {
+            if (string.IsNullOrWhiteSpace(newCard.BaseCard))
+            {
+                Plugin.Logger.LogError($"Upgraded Card: '{newCard.CardName}' '{newCard.CardUpgraded}' is missing the required json field 'baseCard'.");
+                return null;
+            }
+        }
         return newCard;
     }
 }

--- a/Patches/CustomDataLoader/CreateGameContent.cs
+++ b/Patches/CustomDataLoader/CreateGameContent.cs
@@ -36,31 +36,31 @@ public class CreateGameContent
             }
             catch (Exception ex)
             {
-                Plugin.Logger.LogError($"{nameof(CreateCardClonesPrefix)}: Failed to parse card data from json '{itemFileInfo.FullName}'");
+                Plugin.Logger.LogError($"Failed to parse Item data from json '{itemFileInfo.FullName}'");
                 Plugin.Logger.LogError(ex);
             }
         }
     }
 
-    private static void AddItemInternalDictionary(Dictionary<string, ItemData> itemSource, ItemDataWrapper newCard)
+    private static void AddItemInternalDictionary(Dictionary<string, ItemData> itemSource, ItemDataWrapper newItem)
     {
-        Plugin.Logger.LogInfo($"Loading Custom Item: {newCard.name} {newCard.Id}");
+        Plugin.Logger.LogInfo($"Loading Custom Item: {newItem.name} {newItem.Id}");
 
 
-        newCard.Id = newCard.Id.ToLower();
-        itemSource[newCard.Id] = newCard;
-        CustomItems[newCard.Id] = newCard;
+        newItem.Id = newItem.Id.ToLower();
+        itemSource[newItem.Id] = newItem;
+        CustomItems[newItem.Id] = newItem;
     }
 
-    private static ItemDataWrapper LoadItemFromDisk(FileInfo cardFileInfo)
+    private static ItemDataWrapper LoadItemFromDisk(FileInfo itemFileInfo)
     {
-        var json = File.ReadAllText(cardFileInfo.FullName);
+        var json = File.ReadAllText(itemFileInfo.FullName);
         var newItem = ScriptableObject.CreateInstance<ItemDataWrapper>();
         JsonUtility.FromJsonOverwrite(json, newItem);
         if (string.IsNullOrWhiteSpace(newItem.Id))
         {
             newItem.Id = Guid.NewGuid().ToString().ToLower();
-            Plugin.Logger.LogWarning($"Item: '{newItem.Id}' is missing the required field 'id'. Path: {cardFileInfo.FullName}");
+            Plugin.Logger.LogWarning($"Item: '{newItem.Id}' is missing the required field 'id'. Path: {itemFileInfo.FullName}");
             return null;
         }
         else if (RegexUtils.HasInvalidIdRegex.IsMatch(newItem.Id))

--- a/Sample Cards/discover_common.json
+++ b/Sample Cards/discover_common.json
@@ -1,10 +1,6 @@
 {
   "id": "discovercommon",
   "cardName": "The Encyclopedia",
-  "baseCard": "discovercommon",
-  "upgradesTo1": "discovercommon",
-  "upgradesTo2": "discovercommon",
-  "upgradesToC": "discovercommon",
   "cardRarity": 0,
   "cardType": 0,
   "cardClass": -1,

--- a/Sample Cards/discover_common_a.json
+++ b/Sample Cards/discover_common_a.json
@@ -1,9 +1,7 @@
 {
-  "id": "discovercommon",
   "cardName": "The Encyclopedia",
   "baseCard": "discovercommon",
   "cardUpgraded": 1,
-  "upgradedFrom": "discovercommon",
   "cardRarity": 0,
   "cardType": 0,
   "cardClass": -1,

--- a/Sample Cards/discover_common_b.json
+++ b/Sample Cards/discover_common_b.json
@@ -1,9 +1,7 @@
 {
-  "id": "discovercommon",
   "cardName": "The Encyclopedia",
   "baseCard": "discovercommon",
   "cardUpgraded": 2,
-  "upgradedFrom": "discovercommon",
   "cardRarity": 0,
   "cardType": 0,
   "cardClass": -1,

--- a/Sample Cards/discover_common_c.json
+++ b/Sample Cards/discover_common_c.json
@@ -1,9 +1,7 @@
 {
-  "id": "discovercommon",
   "cardName": "The Encyclopedia",
   "baseCard": "discovercommon",
   "cardUpgraded": 3,
-  "upgradedFrom": "discovercommon",
   "cardRarity": 0,
   "cardType": 0,
   "cardClass": -1,


### PR DESCRIPTION
This commit removes the need for the following fields in the json for base white cards:

baseCard
upgradesTo1
upgradesTo2
upgradesToC

This commit removes the need for the following fields in the json for upgraded cards (blue, yellow, corrupted)

id
upgradedFrom

Cards now just automatically assign themselves to their baseCard when it is specified.