### PR TITLE
Fixed Statistics overwrite bugs

### DIFF
--- a/AtO_Loader.csproj
+++ b/AtO_Loader.csproj
@@ -15,6 +15,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="Patches\LoadPlayerData.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Remove="stylecop.json" />
   </ItemGroup>
 

--- a/Data/IDs.cs
+++ b/Data/IDs.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AtO_Loader.Data;
+
+public class IDs
+{
+    /// <summary>
+    /// List of IDs of newly added cards.
+    /// </summary>
+    public static List<string> CustomCardIDsNew { get; set; } = new();
+}

--- a/Patches/DeserializeCards.cs
+++ b/Patches/DeserializeCards.cs
@@ -32,6 +32,12 @@ public class DeserializeCards
         var cardDatas = new CardDataLoader(____CardsSource).LoadData();
         foreach (var cardData in cardDatas)
         {
+            // mark if the card is a new addition (i.e. it's not a tweak to an existing card)
+            if (!____CardsSource.ContainsKey(cardData.Key))
+            {
+                Data.IDs.CustomCardIDsNew.Add(cardData.Key);
+            }
+
             ____CardsSource[cardData.Key] = cardData.Value;
             ___cardsText = string.Concat(new string[]
             {

--- a/Patches/IsCardUnlocked.cs
+++ b/Patches/IsCardUnlocked.cs
@@ -1,5 +1,4 @@
 ﻿using HarmonyLib;
-using static System.Net.Mime.MediaTypeNames;
 
 namespace AtO_Loader.Patches;
 

--- a/Patches/IsCardUnlocked.cs
+++ b/Patches/IsCardUnlocked.cs
@@ -1,4 +1,5 @@
 ﻿using HarmonyLib;
+using static System.Net.Mime.MediaTypeNames;
 
 namespace AtO_Loader.Patches;
 
@@ -6,9 +7,20 @@ namespace AtO_Loader.Patches;
 public class IsCardUnlocked
 {
     [HarmonyPrefix]
-    public static bool SetPatch(ref bool __result)
+    public static bool SetPatch(ref bool __result, string _cardId)
     {
-        __result = true;
-        return false;
+        // Items also use this method to determine if they should be marked as unlocked.
+        // TODO: This new functionality (of only unlocking newly added custom cards) has NOT been
+        //   tested with items, as I couldn't get any custom items to show up in the Tome at all.
+
+        // if the card is a newly added card, mark it as unlocked
+        if (Data.IDs.CustomCardIDsNew.Contains(_cardId))
+        {
+            __result = true;
+            return false;
+        }
+
+        // otherwise just call the IsCardUnlocked function like normal
+        return true;
     }
 }

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -31,7 +31,7 @@ public partial class Plugin : BaseUnityPlugin
         this.harmony.PatchAll(typeof(DeserializeSubClasses));
         this.harmony.PatchAll(typeof(IsCardUnlocked));
         this.harmony.PatchAll(typeof(GetKeyNotesData));
-        this.harmony.PatchAll(typeof(LoadPlayerData));
+        //this.harmony.PatchAll(typeof(LoadPlayerData));
         this.harmony.PatchAll(typeof(SetScore));
         this.harmony.PatchAll(typeof(SetWeeklyScore));
         this.harmony.PatchAll(typeof(SetObeliskScore));

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -31,7 +31,6 @@ public partial class Plugin : BaseUnityPlugin
         this.harmony.PatchAll(typeof(DeserializeSubClasses));
         this.harmony.PatchAll(typeof(IsCardUnlocked));
         this.harmony.PatchAll(typeof(GetKeyNotesData));
-        //this.harmony.PatchAll(typeof(LoadPlayerData));
         this.harmony.PatchAll(typeof(SetScore));
         this.harmony.PatchAll(typeof(SetWeeklyScore));
         this.harmony.PatchAll(typeof(SetObeliskScore));


### PR DESCRIPTION
- No longer try to manage modded/unmodded saves.
    Positive Effect: This lets players keep their list of past games, as well as keeping their Tome up to date with which events/bosses they defeated.
    Negative Effect: In general, a user can't continue a run with modded cards if they don't currently have that mod running.
    Negative Effect: "Past Games" entries that had modded cards in a character's deck will be empty for that character (the rest of the run info is saved appropriately).

- Only flags modded cards as being unlocked, otherwise just lets the game handle the unlocking process.
    Neutral Effect: Since we aren't able to save if a modded card was "unlocked" or not in previous runs, this just defaults to unlocking the modded cards.
    Positive Effect: This DOES NOT automatically unlock modded cards with the same IDs as base game cards; this allows mods to include tweaked base game cards without altering the unlock status of those cards, and should allow for safe removal of the mod at any point in the future.